### PR TITLE
style: lowercase class methods

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,6 @@ repos:
         entry: black
         language: system
         types: [python]
-        args:
-        -   "--diff"
 
 -   repo: local
     hooks:

--- a/scripts/compute_all_compositions.py
+++ b/scripts/compute_all_compositions.py
@@ -12,9 +12,9 @@ from gptomics import model, pairengine, composition as comp
 def main(
     modelname: str,
     outputfilename: str,
-    Obiases: bool = True,
-    MLPs: bool = True,
-    LNs: bool = True,
+    out_biases: bool = True,
+    mlps: bool = True,
+    lns: bool = True,
     verbose: bool = True,
     reverse: bool = False,
     wikidenom: bool = False,
@@ -30,9 +30,9 @@ def main(
     df = pairengine.compute_pair_terms(
         m,
         f,
-        Obiases=Obiases,
-        MLPs=MLPs,
-        LNs=LNs,
+        out_biases=out_biases,
+        mlps=mlps,
+        lns=lns,
         verbose=verbose,
         reverse=reverse,
     )
@@ -60,17 +60,17 @@ if __name__ == "__main__":
     ap.add_argument("modelname", type=str, help="model name")
     ap.add_argument("outputfilename", type=str, help="output filename")
     ap.add_argument(
-        "--no_Obiases",
-        dest="Obiases",
+        "--no_out_biases",
+        dest="out_biases",
         action="store_false",
         help="Do not compute terms for attention head bias terms",
     )
     ap.add_argument(
-        "--no_MLPs", dest="MLPs", action="store_false", help="Do not compute MLP terms"
+        "--no_mlps", dest="mlps", action="store_false", help="Do not compute MLP terms"
     )
     ap.add_argument(
-        "--no_LNs",
-        dest="LNs",
+        "--no_lns",
+        dest="lns",
         action="store_false",
         help="Do not compute Layer Norm terms",
     )

--- a/scripts/compute_all_singular_values.py
+++ b/scripts/compute_all_singular_values.py
@@ -14,9 +14,9 @@ colnames = pairengine.STDCOLNAMES + ["SV_index"]
 def main(
     modelname: str,
     outputfilename: str,
-    Obiases: bool = True,
-    MLPs: bool = True,
-    LNs: bool = True,
+    out_biases: bool = True,
+    mlps: bool = True,
+    lns: bool = True,
     verbose: bool = True,
 ) -> None:
     m = model.model_by_name(modelname)
@@ -29,9 +29,9 @@ def main(
         m,
         singular_values,
         colnames=colnames,
-        Obiases=Obiases,
-        MLPs=MLPs,
-        LNs=LNs,
+        out_biases=out_biases,
+        mlps=mlps,
+        lns=lns,
         verbose=verbose,
     )
 
@@ -67,17 +67,17 @@ if __name__ == "__main__":
     )
     ap.add_argument("outputfilename", type=str, help="output filename")
     ap.add_argument(
-        "--no_Obiases",
-        dest="Obiases",
+        "--no_out_biases",
+        dest="out_biases",
         action="store_false",
         help="Do not compute terms for attention head bias terms",
     )
     ap.add_argument(
-        "--no_MLPs", dest="MLPs", action="store_false", help="Do not compute MLP terms"
+        "--no_mlps", dest="mlps", action="store_false", help="Do not compute MLP terms"
     )
     ap.add_argument(
-        "--no_LNs",
-        dest="LNs",
+        "--no_lns",
+        dest="lns",
         action="store_false",
         help="Do not compute Layer Norm terms",
     )

--- a/scripts/compute_principal_components_composition.py
+++ b/scripts/compute_principal_components_composition.py
@@ -12,9 +12,9 @@ from gptomics.svd import SVD
 def main(
     modelname: str,
     outputfilename: str,
-    Obiases: bool = True,
-    MLPs: bool = True,
-    LNs: bool = True,
+    out_biases: bool = True,
+    mlps: bool = True,
+    lns: bool = True,
     verbose: bool = True,
 ) -> None:
     m = model.model_by_name(modelname)
@@ -24,7 +24,12 @@ def main(
         begin = time.time()
 
     df = pairengine.compute_pair_terms(
-        m, principal_component, Obiases=Obiases, MLPs=MLPs, LNs=LNs, verbose=verbose
+        m,
+        principal_component,
+        out_biases=out_biases,
+        mlps=mlps,
+        lns=lns,
+        verbose=verbose,
     )
 
     if verbose:
@@ -62,17 +67,17 @@ if __name__ == "__main__":
     )
     ap.add_argument("outputfilename", type=str, help="output filename")
     ap.add_argument(
-        "--no_Obiases",
-        dest="Obiases",
+        "--no_out_biases",
+        dest="out_biases",
         action="store_false",
         help="Do not compute terms for attention head bias terms",
     )
     ap.add_argument(
-        "--no_MLPs", dest="MLPs", action="store_false", help="Do not compute MLP terms"
+        "--no_mlps", dest="mlps", action="store_false", help="Do not compute MLP terms"
     )
     ap.add_argument(
-        "--no_LNs",
-        dest="LNs",
+        "--no_lns",
+        dest="lns",
         action="store_false",
         help="Do not compute Layer Norm terms",
     )


### PR DESCRIPTION
Changing some methods and arguments to better fit standard python conventions. e.g.,
* `model.QK()` -> `model.qk()`
* `pair_engine(Obiases=False)` -> `pair_engine(out_biases=False)`